### PR TITLE
ENH: Update project name in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)
-project(Mesh3DProcrustesAlignFilter)
+project(Shape)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)

--- a/include/itkMeshProcrustesAlignFilter.h
+++ b/include/itkMeshProcrustesAlignFilter.h
@@ -53,7 +53,7 @@ namespace itk
  * change  Martin Styner, UNC support for single template and initialization with average
  * TODO: Enable/Disable Normalization of centering and scaling to origin
  *
- * \ingroup Mesh3DProcrustesAlignFilter
+ * \ingroup Shape
  *
  */
 template <class TInputMesh, class TOutputMesh>
@@ -79,7 +79,7 @@ public:
   typedef DataObject::Pointer                                                DataObjectPointer;
   typedef typename OutputMeshType::CoordRepType                              CoordRepType;
   typedef vnl_matrix<CoordRepType>                                           MatrixType;
-  typedef AffineTransform<CoordRepType, 3>                                   TransformType;
+  typedef AffineTransform<double, 3>                                         TransformType;
   typedef typename TransformType::Pointer                                    TransformPointer;
   typedef TransformMeshFilter<OutputMeshType, OutputMeshType, TransformType> TransformMeshType;
   typedef typename TransformMeshType::Pointer                                TransformMeshPointer;

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -3,15 +3,15 @@
 get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
 
-# itk_module() defines the module dependencies in Mesh3DProcrustesAlignFilter
-# Mesh3DProcrustesAlignFilter depends on ITKCommon
-# The testing module in Mesh3DProcrustesAlignFilter depends on ITKTestKernel
-# and ITKMetaIO(besides Mesh3DProcrustesAlignFilter and ITKCore)
+# itk_module() defines the module dependencies in ITKShape
+# ITKShape depends on ITKCommon
+# The testing module in ITKShape depends on ITKTestKernel
+# and ITKMetaIO(besides ITKShape and ITKCore)
 # By convention those modules outside of ITK are not prefixed with
 # ITK.
 
 # define the dependencies of the include module and the tests
-itk_module(Mesh3DProcrustesAlignFilter
+itk_module(Shape
   DEPENDS
     ITKCommon
     ITKMesh

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email='itk+community@discourse.itk.org',
     packages=['itk'],
     package_dir={'itk': 'itk'},
-    download_url=r'https://github.com/slicersalt/ITKMesh3DProcrustesAlignFilter',
+    download_url=r'https://github.com/slicersalt/ITKShape',
     description=r'A C++ implementation of Procrustes alignment for 3D meshes.',
     long_description='ITK external module for libraries originally developed in SPHARM-PDM 3D Slicer extension (https://github.com/NIRALUser/SPHARM-PDM).',
     classifiers=[

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,13 @@
 itk_module_test()
 
-set(Mesh3DProcrustesAlignFilterTests
+set(ShapeTests
   itkMeshProcrustesAlignFilterTest.cxx
   )
 
-CreateTestDriver(Mesh3DProcrustesAlignFilter "${Mesh3DProcrustesAlignFilter-Test_LIBRARIES}" "${Mesh3DProcrustesAlignFilterTests}")
+CreateTestDriver(Shape "${Shape-Test_LIBRARIES}" "${ShapeTests}")
 
 itk_add_test(NAME itkMeshProcrustesAlignFilterTest
-  COMMAND Mesh3DProcrustesAlignFilterTestDriver itkMeshProcrustesAlignFilterTest
+  COMMAND ShapeTestDriver itkMeshProcrustesAlignFilterTest
 	DATA{Input/901-L-mesh.vtk}
 	DATA{Input/901-R-mesh.vtk}
     "${CMAKE_CURRENT_BINARY_DIR}/Output.vtk"

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,3 +1,3 @@
-itk_wrap_module(Mesh3DProcrustesAlignFilter)
+itk_wrap_module(Shape)
 itk_auto_load_submodules()
 itk_end_wrap_module()

--- a/wrapping/itkMeshProcrustesAlignFilter.wrap
+++ b/wrapping/itkMeshProcrustesAlignFilter.wrap
@@ -1,7 +1,7 @@
 itk_wrap_include("itkMesh.h")
 
 UNIQUE(types "${WRAP_ITK_SCALAR};D")
-itk_wrap_class("itk::MeshProcrustesAlignFilter" POINTER)
+itk_wrap_class("itk::MeshProcrustesAlignFilter" POINTER_WITH_SUPERCLASS)
   foreach(t ${types})
     itk_wrap_template("M${ITKM_${t}}3M${ITKM_${t}}3"
                         "itk::Mesh< ${ITKT_${t}}, 3>, itk::Mesh< ${ITKT_${t}}, 3>")


### PR DESCRIPTION
The project repository was renamed from `Mesh3DProcrustesAlignTest` to `ITKShape` shortly after creation, but CMake build generation continued to use the previous name. This PR fixes the project name in CMake in preparation for adding to ITK as a remote module per [Issue 22](https://github.com/slicersalt/ITKShape/issues/22).