### PR TITLE
COMP: Use override instead of old ITK macro ITK_OVERRIDE

### DIFF
--- a/include/itkMeshProcrustesAlignFilter.h
+++ b/include/itkMeshProcrustesAlignFilter.h
@@ -200,7 +200,7 @@ public:
   using itk::ProcessObject::MakeOutput;
 
   virtual itk::ProcessObject::DataObjectPointer
-  MakeOutput(itk::ProcessObject::DataObjectPointerArraySizeType idx) ITK_OVERRIDE;
+  MakeOutput(itk::ProcessObject::DataObjectPointerArraySizeType idx) override;
 
   /** Normalization with Scaling on (default)*/
   void
@@ -299,7 +299,7 @@ protected:
 
   /** Performs the alignment. */
   virtual void
-  GenerateData() ITK_OVERRIDE;
+  GenerateData() override;
 
   /** Calculates the center coordinates of the specified input mesh. */
   TranslationType


### PR DESCRIPTION
The error message was:

C:\Dev\ITK-git\Modules\Remote\Shape\include\itkMeshProcrustesAlignFilter.h(203,70): error C2143: syntax error: missing ';' before 'static_assert'